### PR TITLE
Fixed MenuItemPanel Delete MenuItem functionality

### DIFF
--- a/app/src/components/menuitems/MenuItemSwap.jsx
+++ b/app/src/components/menuitems/MenuItemSwap.jsx
@@ -180,7 +180,7 @@ const MenuItemPicklist = () => {
       const parentMenu = menus.find(menu => menu.isSelected);
     
       if (!parentMenu) {
-        alert("Please select parent menu to delete from first.");
+        alert("Please select parent menu to remove item from first.");
         return;
       }
     

--- a/app/src/components/menuitems/assets/MenuItemPanel.jsx
+++ b/app/src/components/menuitems/assets/MenuItemPanel.jsx
@@ -51,13 +51,7 @@ const MenuItemPanel = ({ item, menuID, onSave, onDelete }) => {
             setShowConfirm(false);
         } else {
             // remove current menuID from menuItem's menuIDs array
-            if (item.menuIDs.includes(menuID)) {
-                // Remove the menu ID if it already exists
-                return {
-                    ...item,
-                    menuIDs: item.menuIDs.filter(id => id !== menuID)
-                };
-            }
+            alert("Remove menu item from non Master Menu by moving it in in Integrate Menu.")
         }
     } catch (err) {
       console.error('Error deleting menu item:', err);


### PR DESCRIPTION
MenuItemPanenl.jsx
 - changed so that if user tries to delete an item from a menu that is NOT MasterMenu they are prompted to use IntegrateMenu instead.

MenuItemSwap.jsx
 - changed alert when user tries to move an item without selecting its parent menu for better wording (replace delete with remove)